### PR TITLE
Add endpointDescription for #10

### DIFF
--- a/rfc0001.bs
+++ b/rfc0001.bs
@@ -156,21 +156,49 @@ To be consistent with the current inclusion of `schema:CreativeWork` in the rang
 
 The description of the `schema:documentation` property is updated to:
 
-> A resource that provides further documentation of the services available via the WebAPI, including their operations, parameters etc.
+> Human-readable documentation of the services available via the `WebAPI`, including their operations, parameters etc.
 >
-> The `documentation` property gives specific details of the actual endpoint instances, while the `conformsTo` property is used to indicate the general standard or specification that the endpoints implement.
->
-> Documentation may be expressed in a machine-readable format, such as an OpenAPI (Swagger) description, an OGC GetCapabilities response WFS, ISO-19142, WMS, ISO-19128, a SPARQL Service Description, an OpenSearch or WSDL20 document, a Hydra API description, or otherwise in HTML, text or some other informal mode. The `encodingFormat` of the `CreativeWork` should be used to indicate the use of such formats via their MIME type.
+> `endpointDescription` should be used for machine-readable documentation.
 
-An example should be added to [https://schema.org/documentation](https://schema.org/documentation) as follows:
+### Notes
+
+This proposal makes it clear that the `schema:documentation` property describes the services available via the `WebAPI` in a *human-readable* format, bringing it *partly* in line with the [DCAT v2 to schema.org mapping](https://www.w3.org/TR/vocab-dcat-2/#dcat-sdo) that recommends the `schema:documentation` property for *both* human-readable documentation and <a>machine-readable API definitions</a>. A proposal for a separate `endpointDescription` property reserved for <a>machine-readable API definitions</a> can be found below.
+
+An alternative that was considered was to use `schema:documentation` for *both* human-readable documentation and <a>machine-readable API definitions</a>, bringing it *fully* in line with [DCAT v2](https://www.w3.org/TR/vocab-dcat-2/#Property:data_service_endpoint_description), and the [DCAT v2 to schema.org mapping](https://www.w3.org/TR/vocab-dcat-2/#dcat-sdo). Such an approach was discounted as it would have necessitated the use of "whitelists" of human- and machine-readable `encodingFormat`s by data consumers to distinguish between them, which would have entailed unnecessary complexity and maintenance.
+
+
+## New property `endpointDescription`
+
+
+### Proposal
+
+<table>
+<thead>
+<tr>
+<th>Property</th>
+<th>Domain</th>
+<th>Range</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>`endpointDescription`</td>
+<td>`schema:WebAPI`</td>
+<td>`schema:CreativeWork`</td>
+<td>
+  <p>Machine-readable API definition of the services available via the `WebAPI`, including their operations, parameters etc.</p>
+  <p>Machine-readable formats include OpenAPI (Swagger) description, an OGC GetCapabilities response WFS, ISO-19142, WMS, ISO-19128, a SPARQL Service Description, an OpenSearch or WSDL20 document, or a Hydra API description. The `encodingFormat` of the `CreativeWork` should be used to indicate the use of such formats via their MIME type.</p>
+  <p>The `endpointDescription` property gives specific details of the actual endpoint instances, while the `conformsTo` property is used to indicate the general standard or specification that the endpoints implement.</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+### Examples
 
 ```json
-"documentation": [
-  {
-    "@type": "CreativeWork",
-    "encodingFormat": "text/html",
-    "url": "https://developers.google.com/knowledge-graph/reference/rest/v1"
-  },
+"endpointDescription": [
   {
     "@type": "CreativeWork",
     "encodingFormat": "application/json",
@@ -180,17 +208,16 @@ An example should be added to [https://schema.org/documentation](https://schema.
     "@type": "CreativeWork",
     "encodingFormat": "application/vnd.oai.openapi+json;version=3.0",
     "url": "https://api.apis.guru/v2/specs/googleapis.com/kgsearch/v1/openapi.json"
-  },
+  }
 ],
 ```
 
 ### Notes
 
-This proposal makes it clear that the `schema:documentation` property can also be used for <a>machine-readable API definition</a>s, bringing it in line with [DCAT v2](https://www.w3.org/TR/vocab-dcat-2/#Property:data_service_endpoint_url).
+This proposal brings the property above [directly from DCAT v2](https://www.w3.org/TR/vocab-dcat-2/#Property:data_service_endpoint_description), using `schema:CreativeWork` to be consistent with the range of `schema:documentation`.
 
-Note that the [DCAT v2 to schema.org mapping](https://www.w3.org/TR/vocab-dcat-2/#dcat-sdo) recommends the `schema:documentation` property for `dcat:endpointDescription`, as above.
+The [DCAT v2 to schema.org mapping](https://www.w3.org/TR/vocab-dcat-2/#dcat-sdo) uses the `schema:documentation` property for both human- and machine-readable documentation, however in order to create an explicit separation between human-readable `documentation` and machine-readable `endpointDescription`, a specific property has been defined.
 
-An alternative that was considered was to create an additional property, `schema:endpointDescription` with range `schema:CreativeWork`, in order to create a more explicit separation between human-readable `documentation`, and machine-readable `endpointDescription`.
 
 ## New property `conformsTo`
 
@@ -423,12 +450,8 @@ A fuller example of a `WebAPI` annotation, including the proposed properties.
   "@type": "WebAPI",
   "name": "Google Knowledge Graph Search API",
   "description": "The Knowledge Graph Search API lets you find entities in the Google Knowledge Graph. The API uses standard schema.org types and is compliant with the JSON-LD specification.",
-  "documentation": [
-    {
-      "@type": "CreativeWork",
-      "encodingFormat": "text/html",
-      "url": "https://developers.google.com/knowledge-graph/reference/rest/v1"
-    },
+  "documentation": "https://developers.google.com/knowledge-graph/reference/rest/v1",
+  "endpointDescription": [
     {
       "@type": "CreativeWork",
       "encodingFormat": "application/json",
@@ -438,7 +461,7 @@ A fuller example of a `WebAPI` annotation, including the proposed properties.
       "@type": "CreativeWork",
       "encodingFormat": "application/vnd.oai.openapi+json;version=3.0",
       "url": "https://api.apis.guru/v2/specs/googleapis.com/kgsearch/v1/openapi.json"
-    },
+    }
   ],
   "url": "https://developers.google.com/knowledge-graph/",
   "termsOfService": "https://developers.google.com/knowledge-graph/terms",

--- a/rfc0001.html
+++ b/rfc0001.html
@@ -1221,7 +1221,7 @@ Possible extra rowspan handling
 		}
 	}
 </style>
-  <meta content="Bikeshed version 40de15f9, updated Thu Jun 11 17:47:04 2020 -0700" name="generator">
+  <meta content="Bikeshed version 7c63c139, updated Fri Jul 17 17:12:19 2020 -0700" name="generator">
   <link href="https://webapi-discovery.github.io/rfcs/rfc0001.html" rel="canonical">
 <style>/* style-autolinks */
 
@@ -1514,44 +1514,51 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
         <li><a href="#notes①"><span class="secno">3.2.2</span> <span class="content">Notes</span></a>
        </ol>
       <li>
-       <a href="#new-property-conformsto"><span class="secno">3.3</span> <span class="content">New property <code>conformsTo</code></span></a>
+       <a href="#new-property-endpointdescription"><span class="secno">3.3</span> <span class="content">New property <code>endpointDescription</code></span></a>
        <ol class="toc">
         <li><a href="#proposal②"><span class="secno">3.3.1</span> <span class="content">Proposal</span></a>
-        <li><a href="#example"><span class="secno">3.3.2</span> <span class="content">Example</span></a>
+        <li><a href="#examples①"><span class="secno">3.3.2</span> <span class="content">Examples</span></a>
         <li><a href="#notes②"><span class="secno">3.3.3</span> <span class="content">Notes</span></a>
        </ol>
       <li>
-       <a href="#new-property-accessservice"><span class="secno">3.4</span> <span class="content">New property <code>accessService</code></span></a>
+       <a href="#new-property-conformsto"><span class="secno">3.4</span> <span class="content">New property <code>conformsTo</code></span></a>
        <ol class="toc">
         <li><a href="#proposal③"><span class="secno">3.4.1</span> <span class="content">Proposal</span></a>
-        <li><a href="#example①"><span class="secno">3.4.2</span> <span class="content">Example</span></a>
+        <li><a href="#example"><span class="secno">3.4.2</span> <span class="content">Example</span></a>
         <li><a href="#notes③"><span class="secno">3.4.3</span> <span class="content">Notes</span></a>
        </ol>
       <li>
-       <a href="#add-webapi-to-domain-of-version"><span class="secno">3.5</span> <span class="content">Add <code>WebAPI</code> to domain of <code>version</code></span></a>
+       <a href="#new-property-accessservice"><span class="secno">3.5</span> <span class="content">New property <code>accessService</code></span></a>
        <ol class="toc">
         <li><a href="#proposal④"><span class="secno">3.5.1</span> <span class="content">Proposal</span></a>
-        <li><a href="#example②"><span class="secno">3.5.2</span> <span class="content">Example</span></a>
+        <li><a href="#example①"><span class="secno">3.5.2</span> <span class="content">Example</span></a>
         <li><a href="#notes④"><span class="secno">3.5.3</span> <span class="content">Notes</span></a>
        </ol>
       <li>
-       <a href="#new-property-apitransport"><span class="secno">3.6</span> <span class="content">New property <code>apiTransport</code></span></a>
+       <a href="#add-webapi-to-domain-of-version"><span class="secno">3.6</span> <span class="content">Add <code>WebAPI</code> to domain of <code>version</code></span></a>
        <ol class="toc">
         <li><a href="#proposal⑤"><span class="secno">3.6.1</span> <span class="content">Proposal</span></a>
-        <li><a href="#example③"><span class="secno">3.6.2</span> <span class="content">Example</span></a>
+        <li><a href="#example②"><span class="secno">3.6.2</span> <span class="content">Example</span></a>
         <li><a href="#notes⑤"><span class="secno">3.6.3</span> <span class="content">Notes</span></a>
        </ol>
       <li>
-       <a href="#add-webapi-to-domain-of-license"><span class="secno">3.7</span> <span class="content">Add <code>WebAPI</code> to domain of <code>license</code></span></a>
+       <a href="#new-property-apitransport"><span class="secno">3.7</span> <span class="content">New property <code>apiTransport</code></span></a>
        <ol class="toc">
         <li><a href="#proposal⑥"><span class="secno">3.7.1</span> <span class="content">Proposal</span></a>
-        <li><a href="#example④"><span class="secno">3.7.2</span> <span class="content">Example</span></a>
+        <li><a href="#example③"><span class="secno">3.7.2</span> <span class="content">Example</span></a>
+        <li><a href="#notes⑥"><span class="secno">3.7.3</span> <span class="content">Notes</span></a>
        </ol>
       <li>
-       <a href="#add-url-to-the-webapi-example"><span class="secno">3.8</span> <span class="content">Add <code>url</code> to the <code>WebAPI</code> example</span></a>
+       <a href="#add-webapi-to-domain-of-license"><span class="secno">3.8</span> <span class="content">Add <code>WebAPI</code> to domain of <code>license</code></span></a>
        <ol class="toc">
         <li><a href="#proposal⑦"><span class="secno">3.8.1</span> <span class="content">Proposal</span></a>
-        <li><a href="#notes⑥"><span class="secno">3.8.2</span> <span class="content">Notes</span></a>
+        <li><a href="#example④"><span class="secno">3.8.2</span> <span class="content">Example</span></a>
+       </ol>
+      <li>
+       <a href="#add-url-to-the-webapi-example"><span class="secno">3.9</span> <span class="content">Add <code>url</code> to the <code>WebAPI</code> example</span></a>
+       <ol class="toc">
+        <li><a href="#proposal⑧"><span class="secno">3.9.1</span> <span class="content">Proposal</span></a>
+        <li><a href="#notes⑦"><span class="secno">3.9.2</span> <span class="content">Notes</span></a>
        </ol>
      </ol>
     <li>
@@ -1653,17 +1660,33 @@ Parts of this work may be from another specification document.  If so, those par
    <h4 class="heading settled" data-level="3.2.1" id="proposal①"><span class="secno">3.2.1. </span><span class="content">Proposal</span><a class="self-link" href="#proposal①"></a></h4>
    <p>The description of the <code>schema:documentation</code> property is updated to:</p>
    <blockquote>
-    <p>A resource that provides further documentation of the services available via the WebAPI, including their operations, parameters etc.</p>
-    <p>The <code>documentation</code> property gives specific details of the actual endpoint instances, while the <code>conformsTo</code> property is used to indicate the general standard or specification that the endpoints implement.</p>
-    <p>Documentation may be expressed in a machine-readable format, such as an OpenAPI (Swagger) description, an OGC GetCapabilities response WFS, ISO-19142, WMS, ISO-19128, a SPARQL Service Description, an OpenSearch or WSDL20 document, a Hydra API description, or otherwise in HTML, text or some other informal mode. The <code>encodingFormat</code> of the <code>CreativeWork</code> should be used to indicate the use of such formats via their MIME type.</p>
+    <p>Human-readable documentation of the services available via the <code>WebAPI</code>, including their operations, parameters etc.</p>
+    <p><code>endpointDescription</code> should be used for machine-readable documentation.</p>
    </blockquote>
-   <p>An example should be added to <a href="https://schema.org/documentation">https://schema.org/documentation</a> as follows:</p>
-<pre class="language-json highlight"><c- u>"documentation"</c->: <c- p>[</c->
-  <c- p>{</c->
-    <c- f>"@type"</c-><c- p>:</c-> <c- u>"CreativeWork"</c-><c- p>,</c->
-    <c- f>"encodingFormat"</c-><c- p>:</c-> <c- u>"text/html"</c-><c- p>,</c->
-    <c- f>"url"</c-><c- p>:</c-> <c- u>"https://developers.google.com/knowledge-graph/reference/rest/v1"</c->
-  <c- p>},</c->
+   <h4 class="heading settled" data-level="3.2.2" id="notes①"><span class="secno">3.2.2. </span><span class="content">Notes</span><a class="self-link" href="#notes①"></a></h4>
+   <p>This proposal makes it clear that the <code>schema:documentation</code> property describes the services available via the <code>WebAPI</code> in a <em>human-readable</em> format, bringing it <em>partly</em> in line with the <a href="https://www.w3.org/TR/vocab-dcat-2/#dcat-sdo">DCAT v2 to schema.org mapping</a> that recommends the <code>schema:documentation</code> property for <em>both</em> human-readable documentation and <a data-link-type="dfn" href="#machine-readable-api-definition" id="ref-for-machine-readable-api-definition">machine-readable API definitions</a>. A proposal for a separate <code>endpointDescription</code> property reserved for <a data-link-type="dfn" href="#machine-readable-api-definition" id="ref-for-machine-readable-api-definition①">machine-readable API definitions</a> can be found below.</p>
+   <p>An alternative that was considered was to use <code>schema:documentation</code> for <em>both</em> human-readable documentation and <a data-link-type="dfn" href="#machine-readable-api-definition" id="ref-for-machine-readable-api-definition②">machine-readable API definitions</a>, bringing it <em>fully</em> in line with <a href="https://www.w3.org/TR/vocab-dcat-2/#Property:data_service_endpoint_description">DCAT v2</a>, and the <a href="https://www.w3.org/TR/vocab-dcat-2/#dcat-sdo">DCAT v2 to schema.org mapping</a>. Such an approach was discounted as it would have necessitated the use of "whitelists" of human- and machine-readable <code>encodingFormat</code>s by data consumers to distinguish between them, which would have entailed unnecessary complexity and maintenance.</p>
+   <h3 class="heading settled" data-level="3.3" id="new-property-endpointdescription"><span class="secno">3.3. </span><span class="content">New property <code>endpointDescription</code></span><a class="self-link" href="#new-property-endpointdescription"></a></h3>
+   <h4 class="heading settled" data-level="3.3.1" id="proposal②"><span class="secno">3.3.1. </span><span class="content">Proposal</span><a class="self-link" href="#proposal②"></a></h4>
+   <table>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Domain
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td><code>endpointDescription</code>
+      <td><code>schema:WebAPI</code>
+      <td><code>schema:CreativeWork</code>
+      <td>
+       <p>Machine-readable API definition of the services available via the <code>WebAPI</code>, including their operations, parameters etc.</p>
+       <p>Machine-readable formats include OpenAPI (Swagger) description, an OGC GetCapabilities response WFS, ISO-19142, WMS, ISO-19128, a SPARQL Service Description, an OpenSearch or WSDL20 document, or a Hydra API description. The <code>encodingFormat</code> of the <code>CreativeWork</code> should be used to indicate the use of such formats via their MIME type.</p>
+       <p>The <code>endpointDescription</code> property gives specific details of the actual endpoint instances, while the <code>conformsTo</code> property is used to indicate the general standard or specification that the endpoints implement.</p>
+   </table>
+   <h4 class="heading settled" data-level="3.3.2" id="examples①"><span class="secno">3.3.2. </span><span class="content">Examples</span><a class="self-link" href="#examples①"></a></h4>
+<pre class="language-json highlight"><c- u>"endpointDescription"</c->: <c- p>[</c->
   <c- p>{</c->
     <c- f>"@type"</c-><c- p>:</c-> <c- u>"CreativeWork"</c-><c- p>,</c->
     <c- f>"encodingFormat"</c-><c- p>:</c-> <c- u>"application/json"</c-><c- p>,</c->
@@ -1673,15 +1696,14 @@ Parts of this work may be from another specification document.  If so, those par
     <c- f>"@type"</c-><c- p>:</c-> <c- u>"CreativeWork"</c-><c- p>,</c->
     <c- f>"encodingFormat"</c-><c- p>:</c-> <c- u>"application/vnd.oai.openapi+json;version=3.0"</c-><c- p>,</c->
     <c- f>"url"</c-><c- p>:</c-> <c- u>"https://api.apis.guru/v2/specs/googleapis.com/kgsearch/v1/openapi.json"</c->
-  <c- p>},</c->
+  <c- p>}</c->
 <c- p>]</c->,
 </pre>
-   <h4 class="heading settled" data-level="3.2.2" id="notes①"><span class="secno">3.2.2. </span><span class="content">Notes</span><a class="self-link" href="#notes①"></a></h4>
-   <p>This proposal makes it clear that the <code>schema:documentation</code> property can also be used for <a data-link-type="dfn" href="#machine-readable-api-definition" id="ref-for-machine-readable-api-definition">machine-readable API definition</a>s, bringing it in line with <a href="https://www.w3.org/TR/vocab-dcat-2/#Property:data_service_endpoint_url">DCAT v2</a>.</p>
-   <p>Note that the <a href="https://www.w3.org/TR/vocab-dcat-2/#dcat-sdo">DCAT v2 to schema.org mapping</a> recommends the <code>schema:documentation</code> property for <code>dcat:endpointDescription</code>, as above.</p>
-   <p>An alternative that was considered was to create an additional property, <code>schema:endpointDescription</code> with range <code>schema:CreativeWork</code>, in order to create a more explicit separation between human-readable <code>documentation</code>, and machine-readable <code>endpointDescription</code>.</p>
-   <h3 class="heading settled" data-level="3.3" id="new-property-conformsto"><span class="secno">3.3. </span><span class="content">New property <code>conformsTo</code></span><a class="self-link" href="#new-property-conformsto"></a></h3>
-   <h4 class="heading settled" data-level="3.3.1" id="proposal②"><span class="secno">3.3.1. </span><span class="content">Proposal</span><a class="self-link" href="#proposal②"></a></h4>
+   <h4 class="heading settled" data-level="3.3.3" id="notes②"><span class="secno">3.3.3. </span><span class="content">Notes</span><a class="self-link" href="#notes②"></a></h4>
+   <p>This proposal brings the property above <a href="https://www.w3.org/TR/vocab-dcat-2/#Property:data_service_endpoint_description">directly from DCAT v2</a>, using <code>schema:CreativeWork</code> to be consistent with the range of <code>schema:documentation</code>.</p>
+   <p>The <a href="https://www.w3.org/TR/vocab-dcat-2/#dcat-sdo">DCAT v2 to schema.org mapping</a> uses the <code>schema:documentation</code> property for both human- and machine-readable documentation, however in order to create an explicit separation between human-readable <code>documentation</code> and machine-readable <code>endpointDescription</code>, a specific property has been defined.</p>
+   <h3 class="heading settled" data-level="3.4" id="new-property-conformsto"><span class="secno">3.4. </span><span class="content">New property <code>conformsTo</code></span><a class="self-link" href="#new-property-conformsto"></a></h3>
+   <h4 class="heading settled" data-level="3.4.1" id="proposal③"><span class="secno">3.4.1. </span><span class="content">Proposal</span><a class="self-link" href="#proposal③"></a></h4>
    <table>
     <thead>
      <tr>
@@ -1696,16 +1718,16 @@ Parts of this work may be from another specification document.  If so, those par
       <td><code>schema:URL</code>
       <td>The URL reference of an established standard to which the described API conforms, for example <code>https://jsonapi.org/format/1.0/</code>, <code>https://grpc.io/</code>, or <code>http://www.hydra-cg.com/spec/latest/core/</code>.
    </table>
-   <h4 class="heading settled" data-level="3.3.2" id="example"><span class="secno">3.3.2. </span><span class="content">Example</span><a class="self-link" href="#example"></a></h4>
+   <h4 class="heading settled" data-level="3.4.2" id="example"><span class="secno">3.4.2. </span><span class="content">Example</span><a class="self-link" href="#example"></a></h4>
 <pre class="language-json highlight"><c- u>"conformsTo"</c->: <c- p>[</c->
   <c- u>"https://jsonapi.org/format/1.0/"</c->
 <c- p>]</c->,
 </pre>
-   <h4 class="heading settled" data-level="3.3.3" id="notes②"><span class="secno">3.3.3. </span><span class="content">Notes</span><a class="self-link" href="#notes②"></a></h4>
+   <h4 class="heading settled" data-level="3.4.3" id="notes③"><span class="secno">3.4.3. </span><span class="content">Notes</span><a class="self-link" href="#notes③"></a></h4>
    <p>This proposal brings the property <a href="https://www.w3.org/TR/vocab-dcat-2/#Property:data_service_endpoint_url">directly from DCAT v2</a>.</p>
    <p>The <a href="https://www.w3.org/TR/vocab-dcat-2/#dcat-sdo">DCAT v2 to schema.org mapping</a> does not include <code>conformsTo</code>. The mapping gap was recognised in <a href="https://ec-jrc.github.io/dcat-ap-to-schema-org/#mapping-properties-dataset">previous mapping attempts</a> and not addressed within <a href="https://github.com/w3c/dxwg/issues/251">DCAT v2 discussions</a>.</p>
-   <h3 class="heading settled" data-level="3.4" id="new-property-accessservice"><span class="secno">3.4. </span><span class="content">New property <code>accessService</code></span><a class="self-link" href="#new-property-accessservice"></a></h3>
-   <h4 class="heading settled" data-level="3.4.1" id="proposal③"><span class="secno">3.4.1. </span><span class="content">Proposal</span><a class="self-link" href="#proposal③"></a></h4>
+   <h3 class="heading settled" data-level="3.5" id="new-property-accessservice"><span class="secno">3.5. </span><span class="content">New property <code>accessService</code></span><a class="self-link" href="#new-property-accessservice"></a></h3>
+   <h4 class="heading settled" data-level="3.5.1" id="proposal④"><span class="secno">3.5.1. </span><span class="content">Proposal</span><a class="self-link" href="#proposal④"></a></h4>
    <table>
     <thead>
      <tr>
@@ -1720,7 +1742,7 @@ Parts of this work may be from another specification document.  If so, those par
       <td><code>schema:WebAPI</code>
       <td>An API that provides access to the dataset
    </table>
-   <h4 class="heading settled" data-level="3.4.2" id="example①"><span class="secno">3.4.2. </span><span class="content">Example</span><a class="self-link" href="#example①"></a></h4>
+   <h4 class="heading settled" data-level="3.5.2" id="example①"><span class="secno">3.5.2. </span><span class="content">Example</span><a class="self-link" href="#example①"></a></h4>
 <pre class="language-yaml highlight">{
   <c- s>"@context"</c->: <c- s>"http://schema.org/"</c->,
   <c- s>"@type"</c->: <c- s>"Dataset"</c->,
@@ -1731,20 +1753,20 @@ Parts of this work may be from another specification document.  If so, those par
   }
 }
 </pre>
-   <h4 class="heading settled" data-level="3.4.3" id="notes③"><span class="secno">3.4.3. </span><span class="content">Notes</span><a class="self-link" href="#notes③"></a></h4>
+   <h4 class="heading settled" data-level="3.5.3" id="notes④"><span class="secno">3.5.3. </span><span class="content">Notes</span><a class="self-link" href="#notes④"></a></h4>
    <p>The <a href="https://www.w3.org/TR/vocab-dcat-2/#dcat-sdo">DCAT v2 to schema.org mapping</a> proposes the use of <code>schema:serviceOutput</code> within <code>schema:WebAPI</code> to reference the <code>schema:Dataset</code>. For the inverse, this proposal uses a term <a href="https://www.w3.org/TR/vocab-dcat-2/#Property:data_service_serves_dataset">from DCAT v2</a> to reference <code>schema:WebAPI</code> from <code>schema:Dataset</code>:</p>
    <p>The DCAT v2 term <code>dcat:accessService</code> links a <code>dcat:Distribution</code> (akin to <code>schema:DataDownload</code>) to the <code>dcat:DataService</code>, however given that a <code>schema:WebAPI</code> may allow read/write access to a <code>schema:Dataset</code>, it is not necessarily limited to only a single <code>schema:DataDownload</code>, and may in fact cover an entire <code>schema:Dataset</code>.</p>
    <p>The <a href="https://www.w3.org/TR/vocab-dcat-2/#dcat-sdo">DCAT v2 to schema.org mapping</a> does not include <code>accessService</code>.</p>
-   <h3 class="heading settled" data-level="3.5" id="add-webapi-to-domain-of-version"><span class="secno">3.5. </span><span class="content">Add <code>WebAPI</code> to domain of <code>version</code></span><a class="self-link" href="#add-webapi-to-domain-of-version"></a></h3>
-   <h4 class="heading settled" data-level="3.5.1" id="proposal④"><span class="secno">3.5.1. </span><span class="content">Proposal</span><a class="self-link" href="#proposal④"></a></h4>
+   <h3 class="heading settled" data-level="3.6" id="add-webapi-to-domain-of-version"><span class="secno">3.6. </span><span class="content">Add <code>WebAPI</code> to domain of <code>version</code></span><a class="self-link" href="#add-webapi-to-domain-of-version"></a></h3>
+   <h4 class="heading settled" data-level="3.6.1" id="proposal⑤"><span class="secno">3.6.1. </span><span class="content">Proposal</span><a class="self-link" href="#proposal⑤"></a></h4>
    <p>Add <code>schema:WebAPI</code> to the domain of <code>schema:version</code>, to describe the version of the API.</p>
-   <h4 class="heading settled" data-level="3.5.2" id="example②"><span class="secno">3.5.2. </span><span class="content">Example</span><a class="self-link" href="#example②"></a></h4>
+   <h4 class="heading settled" data-level="3.6.2" id="example②"><span class="secno">3.6.2. </span><span class="content">Example</span><a class="self-link" href="#example②"></a></h4>
 <pre class="language-json highlight"><c- u>"version"</c->: <c- u>"1.0.0"</c->,
 </pre>
-   <h4 class="heading settled" data-level="3.5.3" id="notes④"><span class="secno">3.5.3. </span><span class="content">Notes</span><a class="self-link" href="#notes④"></a></h4>
+   <h4 class="heading settled" data-level="3.6.3" id="notes⑤"><span class="secno">3.6.3. </span><span class="content">Notes</span><a class="self-link" href="#notes⑤"></a></h4>
    <p>This is the version of the API itself, and hence <code>schema:softwareVersion</code>, <code>schema:assemblyVersion</code>, and <code>schemaVersion</code> are not appropriate.</p>
-   <h3 class="heading settled" data-level="3.6" id="new-property-apitransport"><span class="secno">3.6. </span><span class="content">New property <code>apiTransport</code></span><a class="self-link" href="#new-property-apitransport"></a></h3>
-   <h4 class="heading settled" data-level="3.6.1" id="proposal⑤"><span class="secno">3.6.1. </span><span class="content">Proposal</span><a class="self-link" href="#proposal⑤"></a></h4>
+   <h3 class="heading settled" data-level="3.7" id="new-property-apitransport"><span class="secno">3.7. </span><span class="content">New property <code>apiTransport</code></span><a class="self-link" href="#new-property-apitransport"></a></h3>
+   <h4 class="heading settled" data-level="3.7.1" id="proposal⑥"><span class="secno">3.7.1. </span><span class="content">Proposal</span><a class="self-link" href="#proposal⑥"></a></h4>
    <table>
     <thead>
      <tr>
@@ -1759,22 +1781,22 @@ Parts of this work may be from another specification document.  If so, those par
       <td><code>schema:Text</code>
       <td>The type of transport used for the API, such as HTTP, HTTPS, SMTP, MQTT, WS, WSS
    </table>
-   <h4 class="heading settled" data-level="3.6.2" id="example③"><span class="secno">3.6.2. </span><span class="content">Example</span><a class="self-link" href="#example③"></a></h4>
+   <h4 class="heading settled" data-level="3.7.2" id="example③"><span class="secno">3.7.2. </span><span class="content">Example</span><a class="self-link" href="#example③"></a></h4>
 <pre class="language-json highlight"><c- u>"apiTransport"</c->: <c- p>[</c->
   <c- u>"HTTP"</c-><c- p>,</c->
   <c- u>"HTTPS"</c->
 <c- p>]</c->,
 </pre>
-   <h4 class="heading settled" data-level="3.6.3" id="notes⑤"><span class="secno">3.6.3. </span><span class="content">Notes</span><a class="self-link" href="#notes⑤"></a></h4>
+   <h4 class="heading settled" data-level="3.7.3" id="notes⑥"><span class="secno">3.7.3. </span><span class="content">Notes</span><a class="self-link" href="#notes⑥"></a></h4>
    <p>Given the widely recognised acronyms in use for modes of API transport, there is no need to reference an explicit controlled vocabulary.</p>
-   <h3 class="heading settled" data-level="3.7" id="add-webapi-to-domain-of-license"><span class="secno">3.7. </span><span class="content">Add <code>WebAPI</code> to domain of <code>license</code></span><a class="self-link" href="#add-webapi-to-domain-of-license"></a></h3>
-   <h4 class="heading settled" data-level="3.7.1" id="proposal⑥"><span class="secno">3.7.1. </span><span class="content">Proposal</span><a class="self-link" href="#proposal⑥"></a></h4>
+   <h3 class="heading settled" data-level="3.8" id="add-webapi-to-domain-of-license"><span class="secno">3.8. </span><span class="content">Add <code>WebAPI</code> to domain of <code>license</code></span><a class="self-link" href="#add-webapi-to-domain-of-license"></a></h3>
+   <h4 class="heading settled" data-level="3.8.1" id="proposal⑦"><span class="secno">3.8.1. </span><span class="content">Proposal</span><a class="self-link" href="#proposal⑦"></a></h4>
    <p>Add <code>schema:WebAPI</code> to the domain of <code>schema:license</code>, to describe the license for the design/signature of the API.</p>
-   <h4 class="heading settled" data-level="3.7.2" id="example④"><span class="secno">3.7.2. </span><span class="content">Example</span><a class="self-link" href="#example④"></a></h4>
+   <h4 class="heading settled" data-level="3.8.2" id="example④"><span class="secno">3.8.2. </span><span class="content">Example</span><a class="self-link" href="#example④"></a></h4>
 <pre class="language-json highlight"><c- u>"license"</c->: <c- u>"https://creativecommons.org/licenses/by/3.0/"</c->,
 </pre>
-   <h3 class="heading settled" data-level="3.8" id="add-url-to-the-webapi-example"><span class="secno">3.8. </span><span class="content">Add <code>url</code> to the <code>WebAPI</code> example</span><a class="self-link" href="#add-url-to-the-webapi-example"></a></h3>
-   <h4 class="heading settled" data-level="3.8.1" id="proposal⑦"><span class="secno">3.8.1. </span><span class="content">Proposal</span><a class="self-link" href="#proposal⑦"></a></h4>
+   <h3 class="heading settled" data-level="3.9" id="add-url-to-the-webapi-example"><span class="secno">3.9. </span><span class="content">Add <code>url</code> to the <code>WebAPI</code> example</span><a class="self-link" href="#add-url-to-the-webapi-example"></a></h3>
+   <h4 class="heading settled" data-level="3.9.1" id="proposal⑧"><span class="secno">3.9.1. </span><span class="content">Proposal</span><a class="self-link" href="#proposal⑧"></a></h4>
    <p>Include the following in the documentation of <code>schema:WebAPI</code>:</p>
    <blockquote>
     <p>The <code>url</code> property indicates a landing page for the API, which is a Web page that can be navigated to in a Web browser to gain access to the API and/or additional information.</p>
@@ -1783,7 +1805,7 @@ Parts of this work may be from another specification document.  If so, those par
 <pre class="language-json highlight"><c- u>"url"</c->: <c- u>"https://developers.google.com/knowledge-graph/"</c->,
 <c- u>"documentation"</c->: <c- u>"https://developers.google.com/knowledge-graph/reference/rest/v1"</c->,
 </pre>
-   <h4 class="heading settled" data-level="3.8.2" id="notes⑥"><span class="secno">3.8.2. </span><span class="content">Notes</span><a class="self-link" href="#notes⑥"></a></h4>
+   <h4 class="heading settled" data-level="3.9.2" id="notes⑦"><span class="secno">3.9.2. </span><span class="content">Notes</span><a class="self-link" href="#notes⑦"></a></h4>
    <p>The <a href="https://www.w3.org/TR/vocab-dcat-2/#dcat-sdo">DCAT v2 to schema.org mapping</a> overloads the <code>schema:url</code> property for both <code>dcat:endpointURL</code> and <code>dcat:landingPage</code>. Hence <code>url</code> should be used for the landing page of the API (e.g. <a href="https://azure.microsoft.com/en-gb/services/cdn/">https://azure.microsoft.com/en-gb/services/cdn/</a>) rather than the documentation (e.g. <a href="https://docs.microsoft.com/en-gb/azure/cdn/">https://docs.microsoft.com/en-gb/azure/cdn/</a>).</p>
    <div class="non-normative">
     <h2 class="heading settled" data-level="4" id="suggested-values"><span class="secno">4. </span><span class="content">Suggested values</span><a class="self-link" href="#suggested-values"></a></h2>
@@ -1852,12 +1874,8 @@ Parts of this work may be from another specification document.  If so, those par
   <c- f>"@type"</c-><c- p>:</c-> <c- u>"WebAPI"</c-><c- p>,</c->
   <c- f>"name"</c-><c- p>:</c-> <c- u>"Google Knowledge Graph Search API"</c-><c- p>,</c->
   <c- f>"description"</c-><c- p>:</c-> <c- u>"The Knowledge Graph Search API lets you find entities in the Google Knowledge Graph. The API uses standard schema.org types and is compliant with the JSON-LD specification."</c-><c- p>,</c->
-  <c- f>"documentation"</c-><c- p>:</c-> <c- p>[</c->
-    <c- p>{</c->
-      <c- f>"@type"</c-><c- p>:</c-> <c- u>"CreativeWork"</c-><c- p>,</c->
-      <c- f>"encodingFormat"</c-><c- p>:</c-> <c- u>"text/html"</c-><c- p>,</c->
-      <c- f>"url"</c-><c- p>:</c-> <c- u>"https://developers.google.com/knowledge-graph/reference/rest/v1"</c->
-    <c- p>},</c->
+  <c- f>"documentation"</c-><c- p>:</c-> <c- u>"https://developers.google.com/knowledge-graph/reference/rest/v1"</c-><c- p>,</c->
+  <c- f>"endpointDescription"</c-><c- p>:</c-> <c- p>[</c->
     <c- p>{</c->
       <c- f>"@type"</c-><c- p>:</c-> <c- u>"CreativeWork"</c-><c- p>,</c->
       <c- f>"encodingFormat"</c-><c- p>:</c-> <c- u>"application/json"</c-><c- p>,</c->
@@ -1867,7 +1885,7 @@ Parts of this work may be from another specification document.  If so, those par
       <c- f>"@type"</c-><c- p>:</c-> <c- u>"CreativeWork"</c-><c- p>,</c->
       <c- f>"encodingFormat"</c-><c- p>:</c-> <c- u>"application/vnd.oai.openapi+json;version=3.0"</c-><c- p>,</c->
       <c- f>"url"</c-><c- p>:</c-> <c- u>"https://api.apis.guru/v2/specs/googleapis.com/kgsearch/v1/openapi.json"</c->
-    <c- p>},</c->
+    <c- p>}</c->
   <c- p>],</c->
   <c- f>"url"</c-><c- p>:</c-> <c- u>"https://developers.google.com/knowledge-graph/"</c-><c- p>,</c->
   <c- f>"termsOfService"</c-><c- p>:</c-> <c- u>"https://developers.google.com/knowledge-graph/terms"</c-><c- p>,</c->
@@ -2089,7 +2107,7 @@ Parts of this work may be from another specification document.  If so, those par
   <aside class="dfn-panel" data-for="machine-readable-api-definition">
    <b><a href="#machine-readable-api-definition">#machine-readable-api-definition</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-machine-readable-api-definition">3.2.2. Notes</a>
+    <li><a href="#ref-for-machine-readable-api-definition">3.2.2. Notes</a> <a href="#ref-for-machine-readable-api-definition①">(2)</a> <a href="#ref-for-machine-readable-api-definition②">(3)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */


### PR DESCRIPTION
This PR adds `endpointDescription` on the basis of the discussion found in #10: that the current approach would have necessitated the use of "whitelists" of human- and machine-readable `encodingFormat`s by data consumers to distinguish between them, which would have entailed unnecessary complexity and maintenance.

The changes proposed by this PR can be seen rendered in https://openactive.io/rfcs/rfc0001.html